### PR TITLE
Add docker image build workflow

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,8 +1,9 @@
 name: ci
 
 on:
-  release:
-    types: [released]
+  push:
+    tags:
+      - '*'
 
 jobs:
   docker:
@@ -23,4 +24,8 @@ jobs:
         with:
           platforms: linux/386,linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ github.actor }}/distress:latest
+          build-args: |
+            "VERSION=${{ github.ref }}"
+          tags: |
+            ghcr.io/${{ github.actor }}/distress:latest
+            ghcr.io/${{ github.actor }}/distress:${{ github.ref }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -35,7 +35,7 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm64
           push: true
           build-args: |
-            "VERSION=${{ inputs.VERSION }}"
+            "version=${{ inputs.VERSION }}"
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/distress:latest
             ghcr.io/${{ env.OWNER_LC }}/distress:${{ inputs.VERSION }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,9 +1,8 @@
 name: ci
 
 on:
-  push:
-    branches:
-      - 'main'
+  release:
+    types: [released]
 
 jobs:
   docker:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -38,4 +38,4 @@ jobs:
             "VERSION=${{ inputs.VERSION }}"
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/distress:latest
-            ghcr.io/${{ env.OWNER_LC }}/distress:${{ github.ref_name }}
+            ghcr.io/${{ env.OWNER_LC }}/distress:${{ inputs.VERSION }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
+        description: 'version of the docker asset'
         required: true
         type: environment
   

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -19,6 +19,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add username
+        env:
+          OWNER: ${{ github.actor }}
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> $GITHUB_ENV
+      
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -27,5 +34,5 @@ jobs:
           build-args: |
             "VERSION=${{ github.ref }}"
           tags: |
-            ghcr.io/${{ github.actor }}/distress:latest
-            ghcr.io/${{ github.actor }}/distress:${{ github.ref_name }}
+            ghcr.io/${{ env.OWNER_LC }}/distress:latest
+            ghcr.io/${{ env.OWNER_LC }}/distress:${{ github.ref_name }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,27 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/386,linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.actor }}/distress:latest

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -28,4 +28,4 @@ jobs:
             "VERSION=${{ github.ref }}"
           tags: |
             ghcr.io/${{ github.actor }}/distress:latest
-            ghcr.io/${{ github.actor }}/distress:${{ github.ref }}
+            ghcr.io/${{ github.actor }}/distress:${{ github.ref_name }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -6,7 +6,7 @@ on:
       version:
         description: 'version of the docker asset'
         required: true
-        type: environment
+        type: string
   
 jobs:
   docker:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,10 +1,12 @@
 name: ci
 
 on:
-  push:
-    tags:
-      - '*'
-
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: environment
+  
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -32,7 +34,7 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm64
           push: true
           build-args: |
-            "VERSION=${{ github.ref }}"
+            "VERSION=${{ inputs.VERSION }}"
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/distress:latest
             ghcr.io/${{ env.OWNER_LC }}/distress:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG version=0.1.6
+
+FROM alpine:latest
+ARG version
+ARG TARGETPLATFORM
+
+RUN \ 
+  case ${TARGETPLATFORM} in \
+    "linux/386")  asset_name="distress_i686-unknown-linux-musl"  ;; \
+    "linux/amd64")  asset_name="distress_x86_64-unknown-linux-musl"  ;; \
+    "linux/arm64") asset_name="distress_aarch64-unknown-linux-musl"  ;; \
+  esac && \
+  wget https://github.com/Yneth/distress-releases/releases/download/${version}/${asset_name} -O /usr/local/bin/distress && \
+  chmod +x /usr/local/bin/distress
+
+ENTRYPOINT [ "/usr/local/bin/distress" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG version=0.1.6
-
 FROM alpine:latest
 ARG version
 ARG TARGETPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM alpine:latest
 ARG version
+
+FROM alpine:latest
 ARG TARGETPLATFORM
 
 RUN \ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-ARG version
-
 FROM alpine:latest
+ARG version
 ARG TARGETPLATFORM
 
 RUN \ 


### PR DESCRIPTION
This creates container images for 3 archs (linux/386,linux/amd64,linux/arm64) and pushes to ghcr.io registry.
When need to build a new release version, change `ARG version=0.1.6` in the Dockerfile